### PR TITLE
Add repository .gitignore for Python and tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Tooling caches
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Build and packaging outputs
+build/
+dist/
+*.egg-info/
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/


### PR DESCRIPTION
### Motivation
- The repository had no `.gitignore`, which risked committing Python bytecode, virtual environments, tooling caches, build outputs, and editor/OS files by accident.

### Description
- Add a root `.gitignore` that ignores Python bytecode and caches (`__pycache__/`, `*.py[cod]`, `*$py.class`), virtual environment directories (`.venv/`, `venv/`, `env/`, `ENV/`), common tooling caches (`.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/`), build and packaging outputs (`build/`, `dist/`, `*.egg-info/`), and common OS/editor files (`.DS_Store`, `Thumbs.db`, `.vscode/`, `.idea/`).

### Testing
- Verified ignore rules and repository status with `git check-ignore` and status checks, and confirmed the `.gitignore` file was added successfully with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6add5979c8322b39f1ce5bbce97f2)