### PR TITLE
Add .gitignore and make preview size configurable in WebCamCloneGUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# Tooling caches
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+
+# Build and packaging outputs
+build/
+dist/
+*.egg-info/
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/

--- a/WebCamCloneGUI.py
+++ b/WebCamCloneGUI.py
@@ -24,8 +24,10 @@ class WebCamCloneGUI:
         self.preview_thread = None
         self.preview_running = False
         self.always_on_top = False
+        self.preview_width = 220
+        self.preview_height = 165
 
-        # Preview frame - smaller and positioned on the right
+        # Preview frame - positioned on the right
         self.preview_frame = tk.Frame(master)
         self.preview_frame.pack(side=tk.RIGHT, padx=5, pady=5, fill=tk.Y)
         
@@ -412,8 +414,8 @@ class WebCamCloneGUI:
             try:
                 frame = self.vc.get_current_frame()
                 if frame is not None:
-                    # Resize frame for preview (smaller size - 160x120)
-                    preview_frame = cv2.resize(frame, (160, 120))
+                    # Resize frame for preview
+                    preview_frame = cv2.resize(frame, (self.preview_width, self.preview_height))
                     # Mirror the frame horizontally (like a webcam mirror)
                     preview_frame = cv2.flip(preview_frame, 1)
                     # Convert BGR to RGB for PIL
@@ -426,7 +428,7 @@ class WebCamCloneGUI:
                     self.preview_canvas.image = photo  # Keep a reference
             except Exception as e:
                 print(f"Preview error: {e}")
-            # Update every 50ms (20 FPS) - less frequent for smaller preview
+            # Update every 50ms (20 FPS)
             self.master.after(50, lambda: None)
 
     def on_closing(self):


### PR DESCRIPTION
### Motivation
- Add basic repository ignores and make the preview display size configurable so the preview can be adjusted without changing the resize call in code.

### Description
- Add a new `.gitignore` with common Python, virtualenv, tooling cache, build and editor exclusions; and introduce `preview_width` and `preview_height` attributes to `WebCamCloneGUI` and use them in the `cv2.resize` call instead of the hardcoded `(160, 120)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6add5979c8322b39f1ce5bbce97f2)